### PR TITLE
Use the right names for quantise options.

### DIFF
--- a/RadioMusic/RadioMusic.ino
+++ b/RadioMusic/RadioMusic.ino
@@ -337,6 +337,8 @@ uint16_t checkInterface() {
 	if(resetTriggered) {
 		if((changes & CHANNEL_CHANGED) || playState.nextChannel != playState.currentChannel) {
 			playState.channelChanged = true;
+		} else {
+			resetLedTimer = 0;
 		}
 	}
 

--- a/RadioMusic/Settings.cpp
+++ b/RadioMusic/Settings.cpp
@@ -234,10 +234,10 @@ void Settings::applySetting(String settingName, String settingValue) {
 		loopMode = settingValue.toInt();
 	}
 
-	if(settingName.equalsIgnoreCase("quantiseNoteCV") || settingName.equalsIgnoreCase("quantizeNoteCV")) {
+	if(settingName.equalsIgnoreCase("quantiseNoteCV") || settingName.equalsIgnoreCase("quantizeRootCV")) {
 		quantiseRootCV = toBoolean(settingValue);
 	}
-	if(settingName.equalsIgnoreCase("quantiseNotePot") || settingName.equalsIgnoreCase("quantizeNotePot")) {
+	if(settingName.equalsIgnoreCase("quantiseNotePot") || settingName.equalsIgnoreCase("quantizeRootPot")) {
 		quantiseRootPot = toBoolean(settingValue);
 	}
 


### PR DESCRIPTION
Always flash reset LED when reset is triggered.