### PR TITLE
Add platformio configuration.

### DIFF
--- a/RadioMusic/platformio.ini
+++ b/RadioMusic/platformio.ini
@@ -1,0 +1,18 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = teensy
+board = teensy31
+framework = arduino
+


### PR DESCRIPTION
This adds a configuration file for platformio. Platformio is a build system that can be used to compile arduino projects from the command line. Tool chains (compilers/linkers/etc) and libraries are downloaded automatically and cached locally. The configuration file specifies for which target platform to build, so you don't need to set anything up in an IDE.

Platformio can be installed on debian linux, for example, using:
  sudo apt install python3-pip
  sudo pip3 install platformio

Then compile using platformio, enter the directory containing the platformio.ini file and run:
  pio run

To compile and upload to the hardware:
  pio run -t upload

I have not actually tried this on the hardware (I don't have it), but it appears to produce a valid binary.
